### PR TITLE
refactor: use @shared path alias for shared type imports

### DIFF
--- a/server/services/presenceService.ts
+++ b/server/services/presenceService.ts
@@ -1,7 +1,7 @@
 import { Server } from "socket.io";
-import { userRepository } from "../repositories/userRepository.js";
-import { roomRepository } from "../repositories/roomRepository.js";
-import type { PresenceUser } from "../../shared/types.js";
+import { userRepository } from "../repositories/userRepository";
+import { roomRepository } from "../repositories/roomRepository";
+import type { PresenceUser } from "@shared/types";
 
 /**
  * Build and broadcast the full presence snapshot to every connected client.

--- a/server/services/roomService.ts
+++ b/server/services/roomService.ts
@@ -1,7 +1,7 @@
 import { Socket, Server } from "socket.io";
-import { userRepository } from "../repositories/userRepository.js";
-import { roomRepository } from "../repositories/roomRepository.js";
-import { broadcastPresence } from "../services/presenceService.js";
+import { userRepository } from "../repositories/userRepository";
+import { roomRepository } from "../repositories/roomRepository";
+import { broadcastPresence } from "../services/presenceService";
 
 /**
  * Handles room leave + cleanup for a given socket.

--- a/server/socket/handlers/chatHandler.ts
+++ b/server/socket/handlers/chatHandler.ts
@@ -2,7 +2,7 @@ import { Socket, Server } from "socket.io";
 import type {
   SendMessagePayload,
   SendPrivateMessagePayload,
-} from "../../../../shared/types.js";
+} from "@shared/types";
 
 /** Handles room broadcast messages and private (DM) messages. */
 export function registerChatHandlers(socket: Socket, io: Server): void {

--- a/server/socket/handlers/roomHandler.ts
+++ b/server/socket/handlers/roomHandler.ts
@@ -1,9 +1,9 @@
 import { Socket, Server } from "socket.io";
-import { userRepository } from "../../repositories/userRepository.js";
-import { roomRepository } from "../../repositories/roomRepository.js";
-import { broadcastPresence } from "../../services/presenceService.js";
-import { handleLeaveRoom } from "../../services/roomService.js";
-import type { JoinRoomPayload } from "../../../../shared/types.js";
+import { userRepository } from "../../repositories/userRepository";
+import { roomRepository } from "../../repositories/roomRepository";
+import { broadcastPresence } from "../../services/presenceService";
+import { handleLeaveRoom } from "../../services/roomService";
+import type { JoinRoomPayload } from "@shared/types";
 
 /** Handles room lifecycle: create, join, leave, privacy toggling, and cleanup on disconnect. */
 export function registerRoomHandlers(socket: Socket, io: Server): void {

--- a/server/socket/handlers/webrtcHandler.ts
+++ b/server/socket/handlers/webrtcHandler.ts
@@ -3,7 +3,7 @@ import type {
   OfferPayload,
   AnswerPayload,
   IceCandidatePayload,
-} from "../../../../shared/types.js";
+} from "@shared/types";
 
 /**
  * Relays WebRTC signaling messages between peers.

--- a/server/socket/index.ts
+++ b/server/socket/index.ts
@@ -1,8 +1,8 @@
 import { Server, Socket } from "socket.io";
-import { registerUserHandlers } from "./handlers/userHandler.js";
-import { registerRoomHandlers } from "./handlers/roomHandler.js";
-import { registerChatHandlers } from "./handlers/chatHandler.js";
-import { registerWebRTCHandlers } from "./handlers/webrtcHandler.js";
+import { registerUserHandlers } from "./handlers/userHandler";
+import { registerRoomHandlers } from "./handlers/roomHandler";
+import { registerChatHandlers } from "./handlers/chatHandler";
+import { registerWebRTCHandlers } from "./handlers/webrtcHandler";
 
 /** Attach all domain-scoped event handlers to every new socket connection. */
 export function initSocketHandlers(io: Server): void {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -9,7 +9,7 @@ import React, {
 import { socket } from "../lib/socket";
 import { useNotifications } from "../hooks/useNotifications";
 import { playSound } from "../lib/sounds";
-import type { PresenceUser } from "../../shared/types";
+import type { PresenceUser } from "@shared/types";
 
 export type AppStep = "name" | "lobby" | "room";
 

--- a/src/hooks/useMedia.ts
+++ b/src/hooks/useMedia.ts
@@ -7,7 +7,7 @@ interface MediaPreferences {
   startVideoOff: boolean;
 }
 
-interface UseMediaReturn extends MediaPreferences {
+export interface UseMediaReturn extends MediaPreferences {
   audioDevices: MediaDeviceInfo[];
   videoDevices: MediaDeviceInfo[];
   localStream: MediaStream | null;

--- a/src/hooks/useRoom.ts
+++ b/src/hooks/useRoom.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { Socket } from "socket.io-client";
-import type { Message } from "../../shared/types";
+import type { Message } from "@shared/types";
 
 interface UseRoomProps {
   socket: Socket;

--- a/src/hooks/useWebRTC.ts
+++ b/src/hooks/useWebRTC.ts
@@ -6,7 +6,7 @@ import type {
   IncomingOfferPayload,
   IncomingAnswerPayload,
   IncomingIceCandidatePayload,
-} from "../../shared/types";
+} from "@shared/types";
 
 export interface RemoteStream {
   stream: MediaStream;
@@ -51,7 +51,7 @@ export function useWebRTC({ socket, localStream, userName }: UseWebRTCProps) {
   };
 
   const closeAllPeers = () => {
-    Object.values(peersRef.current).forEach((pc) => pc.close());
+    Object.values(peersRef.current).forEach((pc: RTCPeerConnection) => pc.close());
     peersRef.current = {};
     setRemoteStreams({});
   };

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -23,7 +23,7 @@ import { MediaSettingsModal } from "../components/ui/MediaSettingsModal";
 import { cn } from "../lib/utils";
 import type { UseMediaReturn } from "../hooks/useMedia";
 import type { RemoteStream } from "../hooks/useWebRTC";
-import type { Message } from "../../shared/types";
+import type { Message } from "@shared/types";
 
 interface RoomPageProps {
   roomId: string;


### PR DESCRIPTION
## What

- Replace all `../../shared/types.js` and `../../../../shared/types.js` 
  imports with `@shared/types` alias
- Drop `.js` extensions from local server imports (e.g. `userRepository.js` → `userRepository`)
- Export `UseMediaReturn` interface (was missing `export` keyword)
- Add explicit `RTCPeerConnection` type annotation in `useWebRTC.ts`

## Why

Deep relative paths like `../../../../shared/types.js` are fragile — 
moving any file breaks them silently. The `@shared` alias makes imports 
shorter, refactor-safe, and consistent across both server and client code.
